### PR TITLE
Fix typo in footer

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -5,7 +5,7 @@ en:
   tbs-sct: "Treasury Board of Canada Secretariat"
   tbs-sct-url: "https://www.canada.ca/en/treasury-board-secretariat.html"
   hosting: "Hosted on"
-  built-by: "This project was ubilt by the"
+  built-by: "This project was built by the"
   maintained-by: "and is maintained by the"
   contribute: "Contribute to this documentation"
   repo: "Repositories"


### PR DESCRIPTION
“ubilt” -> “built”