### PR TITLE
Fix broken octocat image

### DIFF
--- a/_includes/repositories.html
+++ b/_includes/repositories.html
@@ -2,7 +2,7 @@
     <h2>{{site.data.translations[page.lang].repo}}</h2>
     <ul class="repo-list group">
       <li class="list-icon">
-        <img src="/assets/img/octocat.png" width="25px" alt="">
+        <img src="/track-web-security-compliance/assets/img/octocat.png" width="25px" alt="">
       </li>
       {% for repo in site.data.repos[page.lang] %}
         <li>


### PR DESCRIPTION
I noticed the octocat image link was broken. ![](https://avatars0.githubusercontent.com/u/1545806?s=50&v=4)
![image](https://user-images.githubusercontent.com/1952571/52243831-e4d08b80-28a8-11e9-9b62-7da6924985c2.png)

This should fix it